### PR TITLE
pocket (0.2.13-6)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pocket (0.2.13-6) experimental; urgency=low
+
+  * Bash completion added for pocket and pocket-init.
+
+ -- Vladimir Isaev <v.isaev@metrotek.spb.ru>  Sun, 17 Jan 2016 16:00:09 +0300
+
 pocket (0.2.13-5) experimental; urgency=low
 
   * debian.pocket (0.2.11.2): Fix: `repo`: component name extraction fixed.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: pocket
 Section: main/devel
 Priority: extra
 Maintainer: Paul Wolneykien <manowar@altlinux.org>
-Build-Depends: debhelper (>= 8.0.0), dh-autoreconf, help2man, ruby-ronn
+Build-Depends: debhelper (>= 8.0.0), dh-autoreconf, help2man, ruby-ronn, pkg-config
 Standards-Version: 3.9.2
 Homepage: http://metrotek.spb.ru/
 

--- a/pocket/Makefile.am
+++ b/pocket/Makefile.am
@@ -14,6 +14,10 @@ pocket_init_DESC = pocket chroot initialization and configuration util
 
 html_DATA = debian.html
 
+if ENABLE_BASH_COMPLETION
+  bashcompletion_DATA = completion/pocket completion/pocket-init
+endif
+
 %.inc: %.md
 	ronn --roff $< --pipe >$@
 	sed -i -e '/^\.TH/ d' \

--- a/pocket/completion/pocket
+++ b/pocket/completion/pocket
@@ -1,0 +1,179 @@
+# pocket(1) completion                          -*- shell-script -*-
+#
+# Copyright (C) 2015  Vladimir Isaev <v.isaev@metrotek.spb.ru>
+# Copyright (C) 2015  STC Metrotek [http://metrotek.spb.ru/]
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+_pocket()
+{
+    local cur prev cword
+    _init_completion -s || return
+
+    # dpkg-architecture -L -- too many architectures!
+    arch_words='amd64 armel armhf i386 ia64 mips mipsel powerpc    \
+                ppc64el s390 s390x sparc'
+
+    # For regenerate this list just run this command and
+    # exclude folders.
+    #
+    # _make_target_extract_script - function from Debian
+    # make autocomplete. Sourced by make autocomlete.
+    #
+    # LC_ALL=C make -npq --file=~/pocket/Pocketfile 2>/dev/null | \
+    # sed -nrf <(_make_target_extract_script -d)
+
+    declare -A options_arr=(
+                             ['bootstrap']=''
+                             ['build']=''
+                             ['buildpkg']=''
+                             ['clean']=''
+                             ['clean-builder']=''
+                             ['clean-cache']=''
+                             ['cleanpkg']=''
+                             ['clean-repo']=''
+                             ['default']=''
+                             ['doc']=''
+                             ['docextract']=''
+                             ['download']=''
+                             ['extract']=''
+                             ['filecheck']=''
+                             ['gencontrol']=''
+                             ['getsource']=''
+                             ['help']=''
+                             ['init']='--quiet --verbose --version --help  \
+                                       --config --flavour --avail-flavours \
+                                       --arch --num --repo --update --'
+                             ['install']=''
+                             ['install-builddeps']=''
+                             ['install-buildenv']=''
+                             ['install-check']=''
+                             ['install-clean']=''
+                             ['install-repo']=''
+                             ['install-shell']='--rooter --'
+                             ['rebuild']=''
+                             ['rebuildpkg']=''
+                             ['reinstall-repo']=''
+                             ['repo']=''
+                             ['rm-updated']=''
+                             ['shell']='--rooter --'
+                             ['show-config']=''
+                             ['show-targets']=''
+                             ['sync-in']='--compose --over'
+                             ['sync-out']=''
+                             ['update']=''
+                           )
+
+    action_words=`echo "${!options_arr[@]}"`
+    options_len=${#options_arr[@]}
+
+    action=""
+
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    i=1 # [0] element is program name
+    while [[ $i -lt $COMP_CWORD ]]; do
+        cword="${COMP_WORDS[$i]}"
+
+        # Search for action.
+        if [[ -z $action ]]; then
+            for act in $action_words; do
+                if [[ "$act" == "$cword" ]]; then
+                    action="$act"
+                    break
+                fi
+            done
+        fi
+
+        # Stop completion if '--' finded and it's not current option.
+        if [[ "$cword" == "--" ]]; then
+            return
+        fi
+
+        i=$(( $i + 1 ))
+    done
+
+
+    if [[ -z $action ]]; then
+
+        options='--dir --arch --target --network --repo    \
+                 --quiet --print-dirs --debug --deep-debug \
+                 --dry-run --help --version'
+
+        case $prev in
+            -C|--dir)
+                compopt -o plusdirs
+                COMPREPLY=( $( compgen -A directory -- $cur ) )
+                ;;
+            -a|--arch|\
+            -t|--target)
+                COMPREPLY=( $( compgen -W "$arch_words" -- $cur ) )
+                ;;
+            *)
+                case $cur in
+                    -*)
+                        COMPREPLY=( $( compgen -W "$options" -- $cur ) )
+                        ;;
+                    *)
+                        COMPREPLY=( $( compgen -W "$action_words" -- $cur ) )
+                        ;;
+                esac
+                ;;
+        esac
+
+    else
+
+        options=${options_arr[$action]}
+
+        case $prev in
+            -a|--arch)
+                COMPREPLY=( $( compgen -W "$arch_words" -- $cur ) )
+                ;;
+            -c|--config)
+                compopt -o plusdirs
+                COMPREPLY=( $( compgen -A file -- $cur ) )
+                ;;
+            -n|--num|\
+            -r|--repo|\
+            -f|--flavour)
+                ;;
+            *)
+                case $cur in
+                    -*)
+                        COMPREPLY=( $( compgen -W "$options" -- $cur ) )
+                        ;;
+                    *)
+                        case $action in
+                            sync-in|\
+                            sync-out)
+                                compopt -o plusdirs
+                                COMPREPLY=( $( compgen -A directory -W '.' \
+                                               -- $cur ) )
+                                ;;
+                            init)
+                                compopt -o plusdirs
+                                COMPREPLY=( $( compgen -A directory -- $cur ) )
+                                ;;
+                        esac
+                        ;;
+                esac
+                ;;
+        esac
+
+    fi
+
+} &&
+complete -F _pocket pocket

--- a/pocket/completion/pocket-init
+++ b/pocket/completion/pocket-init
@@ -1,0 +1,73 @@
+# pocket-init(1) completion                 -*- shell-script -*-
+#
+# Copyright (C) 2015  Vladimir Isaev <v.isaev@metrotek.spb.ru>
+# Copyright (C) 2015  STC Metrotek [http://metrotek.spb.ru/]
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+_pocket-init()
+{
+    local cur prev cword
+    _init_completion -s || return
+
+    # dpkg-architecture -L -- too many architectures!
+    arch_words='amd64 armel armhf i386 ia64 mips mipsel powerpc    \
+                ppc64el s390 s390x sparc'
+
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    i=1 # [0] element is program name
+    while [[ $i -lt $COMP_CWORD ]]; do
+        cword="${COMP_WORDS[$i]}"
+
+        # Stop completion if '--' finded and it's not current option.
+        if [[ "$cword" == "--" ]]; then
+            return
+        fi
+
+        i=$(( $i + 1 ))
+    done
+
+    options='--quiet --verbose --version --help --config --flavour \
+             --avail-flavours --arch --num --repo --update --'
+
+    case $prev in
+        -a|--arch)
+            COMPREPLY=( $( compgen -W "$arch_words" -- $cur ) )
+            ;;
+        -c|--config)
+            compopt -o plusdirs
+            COMPREPLY=( $( compgen -A file -- $cur ) )
+            ;;
+        -n|--num|\
+        -r|--repo|\
+        -f|--flavour)
+            ;;
+        *)
+            case $cur in
+                -*)
+                    COMPREPLY=( $( compgen -W "$options" -- $cur ) )
+                    ;;
+                *)
+                    compopt -o plusdirs
+                    COMPREPLY=( $( compgen -A directory -- $cur ) )
+                    ;;
+            esac
+            ;;
+    esac
+
+} &&
+complete -F _pocket-init pocket-init

--- a/pocket/configure.ac
+++ b/pocket/configure.ac
@@ -18,6 +18,20 @@ test -n "$ronn" || AC_MSG_ERROR([ronn program not found])
 AC_CHECK_PROG(help2man,help2man,help2man)
 test -n "$help2man" || AC_MSG_ERROR([help2man program not found])
 
+# Thanks systemd!
+AC_ARG_WITH([bashcompletiondir],
+        AS_HELP_STRING([--with-bashcompletiondir=DIR], [Bash completions directory]),
+        [],
+        [AS_IF([$(pkg-config --exists bash-completion)], [
+                with_bashcompletiondir=$(pkg-config --variable=completionsdir bash-completion)
+        ] , [
+                with_bashcompletiondir=${datadir}/bash-completion/completions
+        ])])
+AM_CONDITIONAL(ENABLE_BASH_COMPLETION, [test "$with_bashcompletiondir" != "no"])
+#AX_NORMALIZE_PATH([with_bashcompletiondir])
+
+AC_SUBST([bashcompletiondir], [$with_bashcompletiondir])
+
 # Output
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/pocket/pocket-init
+++ b/pocket/pocket-init
@@ -66,7 +66,7 @@ while :; do
     -h|--help) show_help;;
     -c|--config) shift; config="$1";;
     -f|--flavour) shift; flavour="$1";;
-    -F|avail-flavours) do_print_flavours;;
+    -F|--avail-flavours) do_print_flavours;;
     -a|--arch) shift; arch="$1";;
     -n|--num) shift; num="$1";;
     -r|--repo) shift; reponame="$1";;


### PR DESCRIPTION
- pocket/completion: Bash completion added for pocket and pocket-init.
- Fix: pocket-init --avail-flavours option misprint fix.
