### PR TITLE
Some usefull fixes from san

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+pocket (0.2.13-12) experimental; urgency=low
+
+ *  Fix: remove all (previously installed) *-builddeps packages 
+         during process of 'cleanpkg' target.	    
+         Sometimes buildprocess stoped because this package
+         stay in unconfigured state (iU)
+ *  Fix: add rebuildpkg target dependency from cleanpkg target
+ *  Fix: allow use of Network during process of 'buildpkg' target	
+         Some packages may require network connection for building.
+ *  Fix: remove '-nc' dpkg-builddep option because of
+         two consecutive build process for different arch
+         failed.
+
+ -- Alexander Buev <a.buev@metrotek.spb.ru>  Wed, 23 Aug 2017 18:10:49 +0400
+
 pocket (0.2.13-11) experimental; urgency=low
 
   * Fix .orig.tar.gz creation: do not include the epoch number into the filename.

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,11 +4,18 @@ pocket (0.2.13-12) experimental; urgency=low
           during process of 'cleanpkg' target.	    
           Sometimes buildprocess stoped because this package
           stay in unconfigured state (iU)
-  *  Fix: add rebuildpkg target dependency from cleanpkg target
+          Also call "apt-get -y autoremove" to deinstall 
+          all (previously installed) dependencies 
+  *  Fix: add rebuildpkg target dependency from cleanpkg target          
+  *  Fix: mark rebuildpkg and build target dependencies as order depedencies          
   *  Fix: allow use of Network during process of 'buildpkg' target	
           Some packages may require network connection for building.
   *  Improve: Added new option NOCLEAN for buildpkg target
           to instruct dpkg-buildpackage tool do not clean it's build directory
+  *  Improve: Added more correct processing of BuildDepends with 
+          build profiles and other keyword with braces ( Ex: dependecy <cross> [!armel] (>=1.1) ) 
+  *  Improve: Added exporting of buildprofile <cross> in case of cross
+          compilation during building & dependecy resolving process.         
 
  -- Alexander Buev <a.buev@metrotek.spb.ru>  Wed, 23 Aug 2017 18:10:49 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,15 +1,14 @@
 pocket (0.2.13-12) experimental; urgency=low
 
- *  Fix: remove all (previously installed) *-builddeps packages 
-         during process of 'cleanpkg' target.	    
-         Sometimes buildprocess stoped because this package
-         stay in unconfigured state (iU)
- *  Fix: add rebuildpkg target dependency from cleanpkg target
- *  Fix: allow use of Network during process of 'buildpkg' target	
-         Some packages may require network connection for building.
- *  Fix: remove '-nc' dpkg-builddep option because of
-         two consecutive build process for different arch
-         failed.
+  *  Fix: remove all (previously installed) *-builddeps packages 
+          during process of 'cleanpkg' target.	    
+          Sometimes buildprocess stoped because this package
+          stay in unconfigured state (iU)
+  *  Fix: add rebuildpkg target dependency from cleanpkg target
+  *  Fix: allow use of Network during process of 'buildpkg' target	
+          Some packages may require network connection for building.
+  *  Improve: Added new option NOCLEAN for buildpkg target
+          to instruct dpkg-buildpackage tool do not clean it's build directory
 
  -- Alexander Buev <a.buev@metrotek.spb.ru>  Wed, 23 Aug 2017 18:10:49 +0400
 

--- a/pocket/ChangeLog
+++ b/pocket/ChangeLog
@@ -9,9 +9,8 @@
 	    Fix: add rebuildpkg target dependency from cleanpkg target
 	    Fix: allow use of Network during process of 'buildpkg' target	
 		 Some packages may require network connection for building.
-	    Fix: remove '-nc' dpkg-builddep option because of
-		 two consecutive build process for different arch
-		 failed.
+	    Improve: Added new option NOCLEAN for buildpkg target
+		 to instruct dpkg-buildpackage tool do not clean it's build directory
 
 2016-10-05  Paul Wolneykien  <manowar@altlinux.org>
 

--- a/pocket/ChangeLog
+++ b/pocket/ChangeLog
@@ -1,3 +1,18 @@
+2017-08-23 Alexander Buev <a.buev@metrotek.spb.ru>
+
+	* debian.pocket (0.2.11.7)
+
+	    Fix: remove all (previously installed) *-builddeps packages 
+	         during process of 'cleanpkg' target.	    
+	         Sometimes buildprocess stoped because this package
+	         stay in unconfigured state (iU)
+	    Fix: add rebuildpkg target dependency from cleanpkg target
+	    Fix: allow use of Network during process of 'buildpkg' target	
+		 Some packages may require network connection for building.
+	    Fix: remove '-nc' dpkg-builddep option because of
+		 two consecutive build process for different arch
+		 failed.
+
 2016-10-05  Paul Wolneykien  <manowar@altlinux.org>
 
 	* debian.pocket (0.2.11.6):

--- a/pocket/ChangeLog
+++ b/pocket/ChangeLog
@@ -2,15 +2,22 @@
 
 	* debian.pocket (0.2.11.7)
 
-	    Fix: remove all (previously installed) *-builddeps packages 
-	         during process of 'cleanpkg' target.	    
-	         Sometimes buildprocess stoped because this package
-	         stay in unconfigured state (iU)
-	    Fix: add rebuildpkg target dependency from cleanpkg target
-	    Fix: allow use of Network during process of 'buildpkg' target	
-		 Some packages may require network connection for building.
-	    Improve: Added new option NOCLEAN for buildpkg target
-		 to instruct dpkg-buildpackage tool do not clean it's build directory
+	  *  Fix: remove all (previously installed) *-builddeps packages 
+	          during process of 'cleanpkg' target.	    
+	          Sometimes buildprocess stoped because this package
+	          stay in unconfigured state (iU)
+	          Also call "apt-get -y autoremove" to deinstall 
+	          all (previously installed) dependencies 
+	  *  Fix: add rebuildpkg target dependency from cleanpkg target          
+	  *  Fix: mark rebuildpkg and build target dependencies as order depedencies          
+	  *  Fix: allow use of Network during process of 'buildpkg' target	
+	          Some packages may require network connection for building.
+	  *  Improve: Added new option NOCLEAN for buildpkg target
+	       	  to instruct dpkg-buildpackage tool do not clean it's build directory
+	  *  Improve: Added more correct processing of BuildDepends with 
+	          build profiles and other keyword with braces ( Ex: dependecy <cross> [!armel] (>=1.1) ) 
+	  *  Improve: Added exporting of buildprofile <cross> in case of cross
+	          compilation during building & dependecy resolving process.         
 
 2016-10-05  Paul Wolneykien  <manowar@altlinux.org>
 

--- a/pocket/debian.pocket
+++ b/pocket/debian.pocket
@@ -767,6 +767,13 @@ cleanpkg: $(BUILDROOT)/.configured
 	@echo '[ $$(find .keep/ -maxdepth 1 -name "*.orig.tar.*" | wc -l) -eq 0 ] || mv .keep/*.orig.tar.* ./' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
 	$(RUN_B) $(abspath $(BUILDROOT)) /.host/entry
+	@echo '$(INFOPFX) Searching for previous *.build-deps package...'
+	@echo '#!/bin/sh -e$(SHOPTS)' >$(BUILDROOT)/.host/entry
+	@echo 'PKGS=$$(dpkg -l | grep build-deps | awk '\'{ print $$\2 }\'')' >>$(BUILDROOT)/.host/entry
+	@echo '[ -z "$${PKGS}"  ] || echo Deleting: "$${PKGS}"' >>$(BUILDROOT)/.host/entry
+	@echo '[ -z "$${PKGS}"  ] || (echo "$${PKGS}" | xargs dpkg -P)' >>$(BUILDROOT)/.host/entry
+	@chmod 0755 $(BUILDROOT)/.host/entry
+	$(RUN_A) $(abspath $(BUILDROOT)) $(FAKEROOT) /.host/entry
 
 ##
 ## * `buildpkg`    Start or continue building the Debian package from
@@ -796,9 +803,9 @@ buildpkg: install-builddeps cleanpkg
 	@echo '    export CONFIG_SITE=/etc/dpkg-cross/cross-config.$(TARGET)' >>$(BUILDROOT)/.host/entry
 	@echo '    export DEB_BUILD_OPTIONS=nocheck' >>$(BUILDROOT)/.host/entry
 	@echo 'fi' >>$(BUILDROOT)/.host/entry
-	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET)) -F -nc -us -uc' >>$(BUILDROOT)/.host/entry
+	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET)) -F -us -uc' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
-	$(RUN_B) $(abspath $(BUILDROOT)) /.host/entry
+	$(if $(SHARE_NETWORK),share_network=$(SHARE_NETWORK)) $(RUN_B) $(abspath $(BUILDROOT)) /.host/entry
 	@touch $(BUILDROOT)/.buildok
 	@$(MAKE) -si -f $(firstword $(MAKEFILE_LIST)) filecheck ARCH=$(ARCH) BUILDROOT=$(BUILDROOT)
 

--- a/pocket/debian.pocket
+++ b/pocket/debian.pocket
@@ -701,7 +701,9 @@ install-builddeps: $(BUILDROOT)/.updated$(if $(TARGET),.$(TARGET)) $(BUILDROOT)/
 	@echo 'if ! dpkg-checkbuilddeps $(if $(TARGET),-a $(TARGET)); then' >>$(BUILDROOT)/.host/entry
 	@echo '  echo "$(INFOPFX) There are unmet dependencies. Preparing deps meta-package..."' >>$(BUILDROOT)/.host/entry
 	@if [ -n "$(TARGET)" ]; then \
-	   echo '  sed -i -e '\''/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/^Build-Depends[^:]*:[[:space:]]*/Build-Depends: /; s/[[:space:]]\+\([^:,()[:space:]]\+\)\([[:space:]]\+([^)]*)\)\?,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^:,()[:space:]]\+\)\([[:space:]]\+([^)]*)\)\?$$/ \1:$(TARGET)\2/ }; /^[[:space:]]/ { s/[[:space:]]\+\([^:,()[:space:]]\+\)\([[:space:]]\+([^)]*)\)\?,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^:,()[:space:]]\+\)\([[:space:]]\+([^)]*)\)\?$$/ \1:$(TARGET)\2/ }; }'\'' debian/control' >>$(BUILDROOT)/.host/entry; \
+	  echo ' sed -i -e '\''/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/^Build-Depends[^:]*:[[:space:]]*/Build-Depends: /; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*$$/ \1:$(TARGET)\2/ }; /^[[:space:]]/ { s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*$$/ \1:$(TARGET)\2/ }; }'\'' debian/control' >>$(BUILDROOT)/.host/entry; \
+	  echo ' BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
+	  echo ' export DEB_BUILD_PROFILES=cross' >>$(BUILDROOT)/.host/entry; \
 	fi
 	@echo '  sed -i -e '\''/^#/ d'\'' debian/control' >>$(BUILDROOT)/.host/entry
 	@echo '  mk-build-deps || ret=$$?' >>$(BUILDROOT)/.host/entry
@@ -737,7 +739,12 @@ install-builddeps: $(BUILDROOT)/.updated$(if $(TARGET),.$(TARGET)) $(BUILDROOT)/
 	   echo 'trap ":" INT TERM QUIT' >>$(BUILDROOT)/.host/entry; \
 	   echo 'cp -a debian/control ../.control.orig' >>$(BUILDROOT)/.host/entry; \
 	   echo 'sed -i -e "/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/:native/:$$(dpkg --print-architecture)/g; }; /^[[:space:]]/ { s/:native/:$$(dpkg --print-architecture)/g; } }" debian/control' >>$(BUILDROOT)/.host/entry; \
-	   echo 'if ! dpkg-checkbuilddeps $(if $(TARGET),-a $(TARGET)); then' >>$(BUILDROOT)/.host/entry; \
+	   if [ "x$(TARGET)" != "x" ]; then \
+	     echo '  sed -i -e '\''/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/^Build-Depends[^:]*:[[:space:]]*/Build-Depends: /; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*$$/ \1:$(TARGET)\2/ }; /^[[:space:]]/ { s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*$$/ \1:$(TARGET)\2/ }; }'\'' debian/control' >>$(BUILDROOT)/.host/entry; \
+	     echo '  BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
+	     echo '  export DEB_BUILD_PROFILES=cross' >>$(BUILDROOT)/.host/entry; \
+	   fi; \
+	   echo 'if ! dpkg-checkbuilddeps $(if $(TARGET),-a $(TARGET)) $${BUILDOPTS}; then' >>$(BUILDROOT)/.host/entry; \
 	   echo '  echo "$(INFOPFX) Something went wrong: the build requirements are still not met!"' >>$(BUILDROOT)/.host/entry; \
 	   echo '  ret=1' >>$(BUILDROOT)/.host/entry; \
 	   echo 'else' >>$(BUILDROOT)/.host/entry; \
@@ -770,8 +777,11 @@ cleanpkg: $(BUILDROOT)/.configured
 	@echo '$(INFOPFX) Searching for previous *.build-deps package...'
 	@echo '#!/bin/sh -e$(SHOPTS)' >$(BUILDROOT)/.host/entry
 	@echo 'PKGS=$$(dpkg -l | grep build-deps | awk '\'{ print $$\2 }\'')' >>$(BUILDROOT)/.host/entry
-	@echo '[ -z "$${PKGS}"  ] || echo Deleting: "$${PKGS}"' >>$(BUILDROOT)/.host/entry
-	@echo '[ -z "$${PKGS}"  ] || (echo "$${PKGS}" | xargs dpkg -P)' >>$(BUILDROOT)/.host/entry
+	@echo 'if [ -n "$${PKGS}"  ]; then' >>$(BUILDROOT)/.host/entry
+	@echo '  echo Deleting: "$${PKGS}"' >>$(BUILDROOT)/.host/entry
+	@echo '  echo "$${PKGS}" | xargs dpkg -P' >>$(BUILDROOT)/.host/entry
+	@echo '  apt-get -y autoremove ' >>$(BUILDROOT)/.host/entry
+	@echo 'fi' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
 	$(RUN_A) $(abspath $(BUILDROOT)) $(FAKEROOT) /.host/entry
 
@@ -796,7 +806,7 @@ cleanpkg: $(BUILDROOT)/.configured
 ##
 ##     The `NOCLEAN=<anything>` parameter can be used to instruct
 ## the `dpkg-buildpackage` tool to skip process of clean it's build directory
-buildpkg: install-builddeps cleanpkg
+buildpkg: | cleanpkg install-builddeps 
 	@echo "$(INFOPFX) Building the package from source (no clean)..."
 	@rm -f $(BUILDROOT)/.buildok
 	@echo '#!/bin/sh -e$(SHOPTS)' >$(BUILDROOT)/.host/entry
@@ -809,7 +819,11 @@ buildpkg: install-builddeps cleanpkg
 	@echo 'BUILDOPTS="-F -us -uc"' >>$(BUILDROOT)/.host/entry
 	@if [ "x$(NOCLEAN)" != "x"  ]; then \
 	  echo 'BUILDOPTS="$${BUILDOPTS} -nc"' >>$(BUILDROOT)/.host/entry; \
-	fi   
+	fi  
+	@if [ "x$(TARGET)" != "x" ]; then \
+	  echo 'BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
+	  echo 'export DEB_BUILD_PROFILES=cross' >>$(BUILDROOT)/.host/entry; \
+	fi
 	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET)) $${BUILDOPTS}' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
 	$(if $(SHARE_NETWORK),share_network=$(SHARE_NETWORK)) $(RUN_B) $(abspath $(BUILDROOT)) /.host/entry
@@ -833,7 +847,7 @@ buildpkg: install-builddeps cleanpkg
 ## repository name (and therefore, the name of its directory) given
 ## at pocket initialization (use `show-config` without parameters to
 ## get it).
-rebuildpkg: getsource install-builddeps
+rebuildpkg: | getsource cleanpkg install-builddeps
 	@echo "$(INFOPFX) Rebuilding binary packages from source..."
 	@rm -f $(BUILDROOT)/.buildok
 	@echo '#!/bin/sh -e$(SHOPTS)' >$(BUILDROOT)/.host/entry
@@ -843,7 +857,12 @@ rebuildpkg: getsource install-builddeps
 	@echo '    export CONFIG_SITE=/etc/dpkg-cross/cross-config.$(TARGET)' >>$(BUILDROOT)/.host/entry
 	@echo '    export DEB_BUILD_OPTIONS=nocheck' >>$(BUILDROOT)/.host/entry
 	@echo 'fi' >>$(BUILDROOT)/.host/entry
-	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET) -B,-b) -us -uc' >>$(BUILDROOT)/.host/entry
+	@echo 'BUILDOPTS="-us -uc"' >>$(BUILDROOT)/.host/entry
+	@if [ -n "$(TARGET)" ]; then \	  
+	  echo 'BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
+	  echo 'export DEB_BUILD_PROFILES=cross' >>$(BUILDROOT)/.host/entry; \
+	fi
+	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET) -B,-b) $${BUILDOPTS}' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
 	$(RUN_B) $(abspath $(BUILDROOT)) /.host/entry
 	@touch $(BUILDROOT)/.buildok

--- a/pocket/debian.pocket
+++ b/pocket/debian.pocket
@@ -793,6 +793,9 @@ cleanpkg: $(BUILDROOT)/.configured
 ## repository name (and therefore, the name of its directory) given
 ## at pocket initialization (use `show-config` without parameters to
 ## get it).
+##
+##     The `NOCLEAN=<anything>` parameter can be used to instruct
+## the `dpkg-buildpackage` tool to skip process of clean it's build directory
 buildpkg: install-builddeps cleanpkg
 	@echo "$(INFOPFX) Building the package from source (no clean)..."
 	@rm -f $(BUILDROOT)/.buildok
@@ -803,7 +806,11 @@ buildpkg: install-builddeps cleanpkg
 	@echo '    export CONFIG_SITE=/etc/dpkg-cross/cross-config.$(TARGET)' >>$(BUILDROOT)/.host/entry
 	@echo '    export DEB_BUILD_OPTIONS=nocheck' >>$(BUILDROOT)/.host/entry
 	@echo 'fi' >>$(BUILDROOT)/.host/entry
-	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET)) -F -us -uc' >>$(BUILDROOT)/.host/entry
+	@echo 'BUILDOPTS="-F -us -uc"' >>$(BUILDROOT)/.host/entry
+	@if [ "x$(NOCLEAN)" != "x"  ]; then \
+	  echo 'BUILDOPTS="$${BUILDOPTS} -nc"' >>$(BUILDROOT)/.host/entry; \
+	fi   
+	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET)) $${BUILDOPTS}' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
 	$(if $(SHARE_NETWORK),share_network=$(SHARE_NETWORK)) $(RUN_B) $(abspath $(BUILDROOT)) /.host/entry
 	@touch $(BUILDROOT)/.buildok


### PR DESCRIPTION
 *  Fix: remove all (previously installed) *-builddeps packages  during process of 'cleanpkg' target.
 *  Fix: add rebuildpkg target dependency from cleanpkg target
 *  Fix: allow use of Network during process of 'buildpkg' target
 *  Fix: remove '-nc' dpkg-buildpackage option.