### PR TITLE
Fixes & Improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ pocket (0.2.13-13) experimental; urgency=low
   *  Fix: gencontrol target now exit normaly if where is 'debian/pocket' dir
   *  Fix: debian/control Build-Depends field - now it's possible to build
          pocket in pocket          
+  *  Improve: added -j <cpunum> option to limit usage of cpucores 
 
  -- Alexander Buev <san@zzz.spb.ru>  Mon, 28 Aug 2017 15:02:58 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+pocket (0.2.13-13) experimental; urgency=low
+
+  *  Fix: Searching for debian/control field 'Build-Depends' now are case insensivitive
+  *  Improve: added CLEANDEP parameter for target 'cleanpkg'
+              to be able optionaly remove all installed dependency packages
+  *  Improve: added action copy-results for copying result of build
+              from pocket chroot to specified directory
+  *  Fix: gencontrol target now exit normaly if where is 'debian/pocket' dir
+  *  Fix: debian/control Build-Depends field - now it's possible to build
+         pocket in pocket          
+
+ -- Alexander Buev <san@zzz.spb.ru>  Mon, 28 Aug 2017 15:02:58 +0400
+
 pocket (0.2.13-12) experimental; urgency=low
 
   *  Fix: remove all (previously installed) *-builddeps packages 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: pocket
 Section: main/devel
 Priority: extra
 Maintainer: Paul Wolneykien <manowar@altlinux.org>
-Build-Depends: debhelper (>= 8.0.0), dh-autoreconf, help2man, ruby-ronn, pkg-config
+Build-Depends: debhelper:all (>= 8.0.0), dh-autoreconf:all, help2man:native, ruby-ronn:all, pkg-config
 Standards-Version: 3.9.2
 Homepage: http://metrotek.spb.ru/
 

--- a/pocket/ChangeLog
+++ b/pocket/ChangeLog
@@ -10,6 +10,7 @@
 	  *  Fix: gencontrol target now exit normaly if where is 'debian/pocket' dir
 	  *  Fix: debian/control Build-Depends field - now it's possible to build
 	          pocket in pocket          
+	  *  Improve: added -j <cpunum> option to limit usage of cpucores 
 
 2017-08-23 Alexander Buev <a.buev@metrotek.spb.ru>
 

--- a/pocket/ChangeLog
+++ b/pocket/ChangeLog
@@ -1,3 +1,16 @@
+2017-08-28 Alexander Buev <san@zzz.spb.ru> 
+
+	* debian.pocket (0.2.13.13)
+
+	  *  Fix: Searching for debian/control field 'Build-Depends' now are case insensivitive
+	  *  Improve: added CLEANDEP parameter for target 'cleanpkg'
+	              to be able optionaly remove all installed dependency packages
+	  *  Improve: added action copy-results for copying result of build
+	              from pocket chroot to specified directory
+	  *  Fix: gencontrol target now exit normaly if where is 'debian/pocket' dir
+	  *  Fix: debian/control Build-Depends field - now it's possible to build
+	          pocket in pocket          
+
 2017-08-23 Alexander Buev <a.buev@metrotek.spb.ru>
 
 	* debian.pocket (0.2.11.7)

--- a/pocket/debian.pocket
+++ b/pocket/debian.pocket
@@ -821,6 +821,10 @@ cleanpkg: $(BUILDROOT)/.configured
 ##
 ##     The `NOCLEAN=<anything>` parameter can be used to instruct
 ## the `dpkg-buildpackage` tool to skip process of clean it's build directory
+##
+##     The `CPUCNT=<number>` parameter can be used to instruct
+## the `dpkg-buildpackage` tool to limit usage of system cpu cores
+##
 buildpkg: | cleanpkg install-builddeps 
 	@echo "$(INFOPFX) Building the package from source (no clean)..."
 	@rm -f $(BUILDROOT)/.buildok
@@ -838,6 +842,9 @@ buildpkg: | cleanpkg install-builddeps
 	@if [ "x$(TARGET)" != "x" ]; then \
 	  echo 'BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
 	  echo 'export DEB_BUILD_PROFILES=cross' >>$(BUILDROOT)/.host/entry; \
+	fi
+	@if [ "x$(CPUCNT)" != "x" ]; then \
+	  echo 'BUILDOPTS="$${BUILDOPTS} -j$(CPUCNT)"' >>$(BUILDROOT)/.host/entry; \
 	fi
 	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET)) $${BUILDOPTS}' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
@@ -862,6 +869,10 @@ buildpkg: | cleanpkg install-builddeps
 ## repository name (and therefore, the name of its directory) given
 ## at pocket initialization (use `show-config` without parameters to
 ## get it).
+##
+##     The `CPUCNT=<number>` parameter can be used to instruct
+## the `dpkg-buildpackage` tool to limit usage of system cpu cores
+##
 rebuildpkg: | getsource cleanpkg install-builddeps
 	@echo "$(INFOPFX) Rebuilding binary packages from source..."
 	@rm -f $(BUILDROOT)/.buildok
@@ -876,6 +887,9 @@ rebuildpkg: | getsource cleanpkg install-builddeps
 	@if [ -n "$(TARGET)" ]; then \	  
 	  echo 'BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
 	  echo 'export DEB_BUILD_PROFILES=cross' >>$(BUILDROOT)/.host/entry; \
+	fi
+	@if [ "x$(CPUCNT)" != "x" ]; then \
+	  echo 'BUILDOPTS="$${BUILDOPTS} -j$(CPUCNT)"' >>$(BUILDROOT)/.host/entry; \
 	fi
 	@echo 'dpkg-buildpackage -d $(if $(TARGET),-a$(TARGET) -B,-b) $${BUILDOPTS}' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry

--- a/pocket/debian.pocket
+++ b/pocket/debian.pocket
@@ -21,7 +21,7 @@
 
 # Pocket flavour and version:
 POCKET_FLAVOUR = debian
-POCKET_VERSION = 0.2.11.6
+POCKET_VERSION = 0.2.11.13
 
 
 # Customization section
@@ -657,12 +657,23 @@ sync-out: $(BUILDROOT)/.configured
 	@echo "$(INFOPFX) Update files in $(abspath $(TO)) from the builder home dir"
 	rsync -a --inplace $(if $(UPDATE),,--update --existing) $(BUILDROOT)$(BUILDER_HOME)/$(SOURCEDIR)/ $(abspath $(TO))
 
+##
+## * `copy-results` Copy all build result files (packages) to specified directory
+## `TO=<path>` destination  directory path.
+##
+copy-results: $(BUILDROOT)/.buildok
+	$(if $(filter sync-out,$(MAKECMDGOALS)),$(if $(TO),,$(error Specify the destination directory to copy into with 'TO=')))	
+	@echo "$(INFOPFX) Copy result files to $(abspath $(TO)) from the builder dir $(BUILDROOT)$(BUILDER_HOME)"
+	find "$(BUILDROOT)$(BUILDER_HOME)" \
+	 -maxdepth 1 -mindepth 1 -type f -not -name '.*' \
+	 '(' -name '*.deb' -or -name '*.dsc' -or -name '*.tar*' -or -name '*.changes' ')' \
+	 -execdir "cp" "{}" "$(TO)" ";"
 
 gencontrol:
 	@echo '#!/bin/sh -e$(SHOPTS)' >$(BUILDROOT)/.host/entry
 	@echo 'cd $(BUILDER_HOME)' >>$(BUILDROOT)/.host/entry
 	@echo 'cd $(SOURCEDIR)' >>$(BUILDROOT)/.host/entry
-	@echo '[ -e debian/pocket ] || exit 0' >>$(BUILDROOT)/.host/entry
+	@echo '[ -f debian/pocket ] || exit 0' >>$(BUILDROOT)/.host/entry
 	@echo 'cp -a debian/control /tmp/control.orig' >>$(BUILDROOT)/.host/entry
 	@echo 'touch -r debian/control /tmp/control.orig' >>$(BUILDROOT)/.host/entry
 	@echo 'if [ -n "$(TARGET)" -a "$(TARGET)" != "$$(dpkg --print-architecture)" ]; then' >>$(BUILDROOT)/.host/entry
@@ -697,7 +708,7 @@ install-builddeps: $(BUILDROOT)/.updated$(if $(TARGET),.$(TARGET)) $(BUILDROOT)/
 	@echo 'trap "mv ../.control.orig debian/control" EXIT' >>$(BUILDROOT)/.host/entry
 	@echo 'trap ":" INT TERM QUIT' >>$(BUILDROOT)/.host/entry
 	@echo 'cp -a debian/control ../.control.orig' >>$(BUILDROOT)/.host/entry
-	@echo 'sed -i -e "/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/:native/:$$(dpkg --print-architecture)/g; }; /^[[:space:]]/ { s/:native/:$$(dpkg --print-architecture)/g; } }" debian/control' >>$(BUILDROOT)/.host/entry
+	@echo 'sed -i -e "/^Build-Depends[^:]*:/I,/^[^[:space:]]/ { /^Build-Depends[^:]*:/I { s/:native/:$$(dpkg --print-architecture)/g; }; /^[[:space:]]/ { s/:native/:$$(dpkg --print-architecture)/g; } }" debian/control' >>$(BUILDROOT)/.host/entry
 	@echo 'if ! dpkg-checkbuilddeps $(if $(TARGET),-a $(TARGET)); then' >>$(BUILDROOT)/.host/entry
 	@echo '  echo "$(INFOPFX) There are unmet dependencies. Preparing deps meta-package..."' >>$(BUILDROOT)/.host/entry
 	@if [ -n "$(TARGET)" ]; then \
@@ -738,7 +749,7 @@ install-builddeps: $(BUILDROOT)/.updated$(if $(TARGET),.$(TARGET)) $(BUILDROOT)/
 	   echo 'trap "mv ../.control.orig debian/control" EXIT' >>$(BUILDROOT)/.host/entry; \
 	   echo 'trap ":" INT TERM QUIT' >>$(BUILDROOT)/.host/entry; \
 	   echo 'cp -a debian/control ../.control.orig' >>$(BUILDROOT)/.host/entry; \
-	   echo 'sed -i -e "/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/:native/:$$(dpkg --print-architecture)/g; }; /^[[:space:]]/ { s/:native/:$$(dpkg --print-architecture)/g; } }" debian/control' >>$(BUILDROOT)/.host/entry; \
+	   echo 'sed -i -e "/^Build-Depends[^:]*:/I,/^[^[:space:]]/ { /^Build-Depends[^:]*:/I { s/:native/:$$(dpkg --print-architecture)/g; }; /^[[:space:]]/ { s/:native/:$$(dpkg --print-architecture)/g; } }" debian/control' >>$(BUILDROOT)/.host/entry; \
 	   if [ "x$(TARGET)" != "x" ]; then \
 	     echo '  sed -i -e '\''/^Build-Depends[^:]*:/,/^[^[:space:]]/ { /^Build-Depends[^:]*:/ { s/^Build-Depends[^:]*:[[:space:]]*/Build-Depends: /; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*$$/ \1:$(TARGET)\2/ }; /^[[:space:]]/ { s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*,/ \1:$(TARGET)\2,/g; s/[[:space:]]\+\([^]:,()<>[:space:]]\+\)\(\([[:space:]]*\(\(([^)]*)\)\|\(<[^>]*>\)\|\([[][^]]*[]]\)\)\)*\)\?[[:space:]]*$$/ \1:$(TARGET)\2/ }; }'\'' debian/control' >>$(BUILDROOT)/.host/entry; \
 	     echo '  BUILDOPTS="$${BUILDOPTS} -Pcross"' >>$(BUILDROOT)/.host/entry; \
@@ -762,6 +773,8 @@ install-builddeps: $(BUILDROOT)/.updated$(if $(TARGET),.$(TARGET)) $(BUILDROOT)/
 ## * `cleanpkg`    Clean (delete) the files produced by the last
 ## package building procedure. The wildcard includes: `*.deb`,
 ## `*.dsc`, `*.changes` and `*.tar.*`.
+##     The `CLEANDEP=<anything>` parameter can be used to 
+## remove all previously installed (as build dependency) packages 
 cleanpkg: $(BUILDROOT)/.configured
 	@echo "$(INFOPFX) Deleting all built packages..."
 	@rm -fv $(BUILDROOT)/.buildok
@@ -780,7 +793,9 @@ cleanpkg: $(BUILDROOT)/.configured
 	@echo 'if [ -n "$${PKGS}"  ]; then' >>$(BUILDROOT)/.host/entry
 	@echo '  echo Deleting: "$${PKGS}"' >>$(BUILDROOT)/.host/entry
 	@echo '  echo "$${PKGS}" | xargs dpkg -P' >>$(BUILDROOT)/.host/entry
-	@echo '  apt-get -y autoremove ' >>$(BUILDROOT)/.host/entry
+	@if [ -n "$(CLEANDEP)" ]; then \
+ 	  echo '  apt-get -y autoremove ' >>$(BUILDROOT)/.host/entry; \
+	fi
 	@echo 'fi' >>$(BUILDROOT)/.host/entry
 	@chmod 0755 $(BUILDROOT)/.host/entry
 	$(RUN_A) $(abspath $(BUILDROOT)) $(FAKEROOT) /.host/entry

--- a/pocket/pocket
+++ b/pocket/pocket
@@ -114,6 +114,9 @@ Action wrappers:
   sync-out <to>     complementary to the above action supplying <to>
                     directory as TO=<to>;
 
+  copy-results <to>   copy result files (packages) to specified directory <to>
+                      directory as TO=<to>;
+
   shell [--rooter] [ -- command... ] invokes the Pocketfile \`shell\`
                                      action; the option \`--rooter\`
                               passes \`ROLE=rooter\` parameter;
@@ -350,6 +353,16 @@ else
             [ -n "$dir" ] || \
                 fatal 'Destination directory is not specified\n'
             invoke 'sync-out' TO="$dir" "$@"
+            ;;
+        copy-results)
+            dir=
+            if [ $# -gt 0 ]; then
+                dir="$(getdir "$1")"
+                shift
+            fi
+            [ -n "$dir" ] || \
+                fatal 'Destination directory is not specified\n'
+            invoke 'copy-results' TO="$dir" "$@"
             ;;
         shell|install-shell)
             role=; params=; cmd=

--- a/pocket/pocket
+++ b/pocket/pocket
@@ -73,6 +73,8 @@ Options:
   -n, --dry-run  print the commands that would be executed, but do
                  not execute them;
 
+  -j --jobs <number>    limit number of processors to use for build process;                 
+
   -h, --help     show this help page and exit;
 
   -V, --version  print the program version information and exit.
@@ -143,7 +145,7 @@ quote()
 myargs=
 while [ $# -gt 0 ]; do
     case "$1" in
-        -C|--dir|-a|--arch|-t|--target|-r|--repo)
+        -C|--dir|-a|--arch|-t|--target|-r|--repo|-j|-jobs)
             if [ $# -le 1 ]; then
                 show_usage
                 exit 1
@@ -161,9 +163,9 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-OPTS=`eval "getopt -n \"$PROG\" -o C:,a:,t:,r:,N,q,w,d,n,h,V -l dir:,arch:,target:,repo:,network,quiet,print-dirs,debug,deep-debug,dry-run,help,version -- $myargs"` || ( ret=$?; show_usage; exit $ret ) >&2
+OPTS=`eval "getopt -n \"$PROG\" -o C:,a:,t:,r:,j:,N,q,w,d,n,h,V -l dir:,arch:,target:,repo:,jobs:,network,quiet,print-dirs,debug,deep-debug,dry-run,help,version -- $myargs"` || ( ret=$?; show_usage; exit $ret ) >&2
 
-dir=; quiet=; printdirs=; debug=; dry=; arch=; target=; network=; reponame=
+dir=; quiet=; printdirs=; debug=; dry=; arch=; target=; network=; reponame=; cpucnt=
 
 argparse() {
     while :; do
@@ -178,6 +180,7 @@ argparse() {
             -N|--network) network=-n;;
             -q|--quiet) quiet=-q;;
             -w|--print-dirs) printdirs=-w;;
+            -j|--jobs) shift; cpucnt="$1";;
             -d|--debug)
                 [ -n "$debug" ] || debug=0
             debug=$((debug + 1))
@@ -218,7 +221,8 @@ do_invoke()
              ${arch:+ARCH="$arch"} \
              ${target:+TARGET="$target"} \
              ${network:+SHARE_NETWORK=yes} \
-             ${reponame:+OUTNAME="$reponame"}
+             ${reponame:+OUTNAME="$reponame"} \
+             ${cpucnt:+CPUCNT="$cpucnt"}
 }
 
 invoke()


### PR DESCRIPTION
  *  Fix: Searching for debian/control field 'Build-Depends' now are case insensivitive
  *  Improve: added CLEANDEP parameter for target 'cleanpkg'
              to be able optionaly remove all installed dependency packages
  *  Improve: added action copy-results for copying result of build
              from pocket chroot to specified directory
  *  Fix: gencontrol target now exit normaly if where is 'debian/pocket' dir 
  *  Fix: debian/control Build-Depends field - now it's possible to build
         pocket in pocket    
  *  Improve: added -j <cpunum> option to limit usage of cpucores 
